### PR TITLE
Removes custom CloudWatch Log Group for CodeBuild

### DIFF
--- a/examples/aws/codebuild_project/codebuild_project.tf
+++ b/examples/aws/codebuild_project/codebuild_project.tf
@@ -240,11 +240,6 @@ module "codebuild_project_s3_logs" {
   ]
 
   codebuild_project_logs_config = [{
-    cloudwatch_logs = [
-      {
-        group_name = module.log_group.cloudwatch_log_group.name
-      }
-    ]
     s3_logs = [{
       status   = "ENABLED"
       location = "${aws_s3_bucket.artifacts.id}/build-log"

--- a/examples/aws/codebuild_project/others.tf
+++ b/examples/aws/codebuild_project/others.tf
@@ -20,11 +20,3 @@ module "security_group" {
 
   tags = var.tags
 }
-
-module "log_group" {
-  source = "../../../modules/aws/cloudwatch_log_group"
-
-  tags = var.tags
-
-  name = "infra-tf-modules-examples-codebuild-project-custom-log-group"
-}

--- a/modules/aws/codebuild_project/codebuild_project.tf
+++ b/modules/aws/codebuild_project/codebuild_project.tf
@@ -132,11 +132,11 @@ resource "aws_codebuild_project" "project" {
 
   dynamic "logs_config" {
     for_each = [for element in var.codebuild_project_logs_config : {
-      cloudwatch_logs = lookup(element, "cloudwatch_logs", [
+      cloudwatch_logs = [
         {
           group_name = module.log_group.cloudwatch_log_group.name
         }
-      ])
+      ]
       s3_logs = lookup(element, "s3_logs", [])
     }]
 

--- a/modules/aws/codebuild_project/docs/optional_parameters.md
+++ b/modules/aws/codebuild_project/docs/optional_parameters.md
@@ -74,13 +74,6 @@ They follow the same name as in the offical Terraform documentation with the add
 
   - Note: This attribute should be passed as an array containing one object with the following parameters:
 
-    - [cloudwatch_logs](https://www.terraform.io/docs/providers/aws/r/codebuild_project.html#cloudwatch_logs)
-
-      - Note: This attribute should be passed as an array containing one object with the following parameters:
-        - [status](https://www.terraform.io/docs/providers/aws/r/codebuild_project.html#status)
-        - [group_name](https://www.terraform.io/docs/providers/aws/r/codebuild_project.html#group_name)
-        - [stream_name](https://www.terraform.io/docs/providers/aws/r/codebuild_project.html#stream_name)
-
     - [s3_logs](https://www.terraform.io/docs/providers/aws/r/codebuild_project.html#s3_logs)
 
       - Note: This attribute should be passed as an array containing one object with the following parameters:
@@ -93,11 +86,6 @@ They follow the same name as in the offical Terraform documentation with the add
   ```
   codebuild_project_logs_config = [
     {
-      cloudwatch_logs = [
-        {
-          group_name = "..."
-        }
-      ],
       s3_logs = [
         {
           status = "..."


### PR DESCRIPTION
Having a conditional creation of the log group started to throw an error saying that Terraform couldn't decide whether the resource should be created or not